### PR TITLE
Update Modelica package to MSL4.0.0

### DIFF
--- a/C/src/ExternalLibraryPython.c
+++ b/C/src/ExternalLibraryPython.c
@@ -233,7 +233,6 @@ out:
 		if (s_callbacks.ModelicaError) {
 			s_callbacks.ModelicaError(error);
 		}
-		return NULL;
 	}
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ if (MSVC)
   string(REPLACE "/MD"  "/MT"  CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
   string(REPLACE "/MDd" "/MTd" CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG}")
   string(REPLACE "/MDd" "/MTd" CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG}")
+
+  # disable CRT deprecation warnings
+  add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif ()
 
 if (WIN32)

--- a/ExternalLibrary/ExternalLibraryObjectExample.mo
+++ b/ExternalLibrary/ExternalLibraryObjectExample.mo
@@ -1,9 +1,9 @@
 within ExternalLibrary;
 model ExternalLibraryObjectExample
   extends Modelica.Icons.Example;
-  Modelica.Blocks.Sources.Sine sine(amplitude=1, freqHz=1)
+  Modelica.Blocks.Sources.Sine sine(amplitude=1)
     annotation (Placement(transformation(extent={{-60,18},{-40,38}})));
-  Modelica.Blocks.Sources.Sine sine1(amplitude=2, freqHz=1)
+  Modelica.Blocks.Sources.Sine sine1(amplitude=2)
     annotation (Placement(transformation(extent={{-60,-40},{-40,-20}})));
   ExternalLibraryObject libraryObject(
     nin=2,

--- a/ExternalLibrary/package.mo
+++ b/ExternalLibrary/package.mo
@@ -2,7 +2,7 @@ within ;
 package ExternalLibrary
   extends Modelica.Icons.Package;
 
-  annotation (uses(Modelica(version="3.2.3")), Icon(graphics={
+  annotation (Icon(graphics={
                                                   Polygon(
           points={{0,40},{0,34},{-54,34},{-54,-64},{44,-64},{44,-10},{50,-10},{
             50,-70},{-60,-70},{-60,40},{0,40}},


### PR DESCRIPTION
The MSL is only used in the test model for the external object. I updated the model in order to use the MSL 4.0.0 by using the conversion script. I also applied auto-format to the code of the test model.

Closes #3