### PR TITLE
Improve flexibiliy of external function

### DIFF
--- a/ExternalLibrary/Internal.mo
+++ b/ExternalLibrary/Internal.mo
@@ -69,8 +69,10 @@ package Internal
     input String moduleName;
     input String functionName;
     input String pythonHome;
-    input Real[2] u;
-    output Real[2] y;
+    input Integer nu;
+    input Real[nu] u;
+    input Integer ny;
+    output Real[ny] y;
     output String errorMessage;
   external"C" errorMessage = externalFunction(
       filename,

--- a/ExternalLibrary/externalLibraryFunction.mo
+++ b/ExternalLibrary/externalLibraryFunction.mo
@@ -14,7 +14,9 @@ algorithm
     moduleName,
     functionName,
     pythonHome,
-    u);
+    size(u, 1),
+    u,
+    size(y, 1));
 
   assert(Modelica.Utilities.Strings.isEmpty(errorMessage), errorMessage);
 end externalLibraryFunction;


### PR DESCRIPTION
Add input arguments for size of input and output vectors
Add size inputs to external function used in its wrapper function

After our discussion I tested the use of input and output arguments with undefined size, but it did not work although it checked. So I had to introduce input arguments for the sizes of the input and output vectors.