### PR TITLE
Use className instead of hardcoded name in createExternalObject()

### DIFF
--- a/C/src/ExternalLibraryPython.c
+++ b/C/src/ExternalLibraryPython.c
@@ -136,7 +136,7 @@ void* createExternalObject(const char* filename, const char* moduleName, const c
 
 	o->methodName = PyUnicode_DecodeFSDefault("evaluate");
 
-	o->class = PyObject_GetAttrString(o->module, "ExternalLibraryObject");
+	o->class = PyObject_GetAttrString(o->module, className);
 
 	//int is_type = PyType_Check(o->class);
 


### PR DESCRIPTION
fixes #16